### PR TITLE
Fix palindrome detection logic

### DIFF
--- a/StringPalindrome.go
+++ b/StringPalindrome.go
@@ -5,25 +5,25 @@ import (
 	"fmt"
 )
 
-func main() {
-	s := "hannnah"
+func isPalindrome(s string) bool {
 	i := 0
 	j := len(s) - 1
-	palindrome := true
-	for i != j {
+
+	for i < j {
 		if s[i] != s[j] {
-			palindrome = false
+			return false
 		}
 		i++
 		j--
-		if i+1 == j {
-			if s[i] != s[j] {
-				palindrome = false
-			}
-			break
-		}
 	}
-	if palindrome {
+
+	return true
+}
+
+func main() {
+	s := "hannnah"
+
+	if isPalindrome(s) {
 		fmt.Println(s, "is a palindrome")
 	} else {
 		fmt.Println(s, "is NOT a palindrome")


### PR DESCRIPTION
## Summary
- simplify palindrome check logic in `StringPalindrome.go` and avoid index errors

## Testing
- `go build StringPalindrome.go`

------
https://chatgpt.com/codex/tasks/task_e_6840487a25548327a0e50a3250e3e69e